### PR TITLE
run: fix log paths in results.json

### DIFF
--- a/run-executor.sh
+++ b/run-executor.sh
@@ -96,10 +96,8 @@ if [ $REMOTE = true ]; then
 		# Adjust artifacts browsing on dashboard
 		RESULT="$(find results -name '*-*' -type f | sort -n -r | head -1)"
 
-		DLINK="$(cat $RESULT | jq .link)"
-		if [[ "$DLINK" =~ raw\.githubusercontent ]]; then
-			ARTIFACTS="$(echo $DLINK | sed 's/raw\.githubusercontent/github/g' | sed -e "s/$STORAGE_BRANCH/tree\/$STORAGE_BRANCH/g")"
-			jq ".link = $ARTIFACTS" "$RESULT" | sponge "$RESULT"
+		if grep -q 'raw\.githubusercontent' $RESULT; then
+			sed -i 's#raw\.githubusercontent\.com/p4tc-dev/tc-executor/#github.com/p4tc-dev/tc-executor/tree/#g' $RESULT
 
 			# Copy container logs to storage
 			ARTPATH="$CUR/$STORAGE/$(jq .link "$RESULT" | grep -o -P 'artifacts\/[0-9]+')"


### PR DESCRIPTION
The "output" links from NIPA's contest page [1] points to a directory in "raw.githubusercontent.com", which is not working, e.g. [2].

The result.json file is already modified to point to 'github.com' instead, but for a bit of time now, there is a second 'link' field in the JSON file, e.g. [3]. It needs to be modified as well.

Instead of converting the fields one by one, one 'sed' command can replace all references to 'githubusercontent.com'.

Link: https://netdev.bots.linux.dev/contest.html?remote=tdc [1]
Link: https://raw.githubusercontent.com/p4tc-dev/tc-executor/storage/artifacts/643403/1-tdc-sh [2]
Link: https://raw.githubusercontent.com/p4tc-dev/tc-executor/storage/results/results-636563.json [3]